### PR TITLE
Proper versioning in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "array-tools": "^1.5.2",
     "command-line-args": "~0.5.1",
     "file-set": "~0.2.1",
-    "jsdoc-75lb": "latest",
+    "jsdoc-75lb": "3.4.0-dev-6",
     "more-fs": "~0.5.0",
     "object-tools": "^1.2.0"
   },


### PR DESCRIPTION
Using latest version is not a good practice. E.g. We are using version `0.3.8` of `jsdoc-parse` which is not giving the proper parameters to `jsdoc-75lb-dev-6` and works flawlessly with `jsdoc-75lb-dev5` which results in time spend tracking down dependencies and their versions. Introducing less breaking changes would also be great :100: 