### PR TITLE
Add missing comma to deep-class.json

### DIFF
--- a/test/expected/deep-class.json
+++ b/test/expected/deep-class.json
@@ -10,7 +10,7 @@
         "id": "module:farm--Farm()",
         "parentId": "module:farm--Farm"
       },
-      { "id": "instance", "kind": "group", "parentId": "module:farm--Farm" }
+      { "id": "instance", "kind": "group", "parentId": "module:farm--Farm" },
       {
         "id": "module:farm--Farm.Farm#equipment",
         "parentId": "instance",


### PR DESCRIPTION
Makes deep-class.json valid JSON. For some strange reason the dev setup in one of my projects highlighted this, and it does seem like a typo. If so, here's a fix.