### PR TITLE
Fix: es6 constructor docs generation (fixes #33)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 tmp
 out
+node_modules
+npm-debug.log

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -133,7 +133,7 @@ function createConstructor (class_) {
   replacements.push(class_)
 
   /* only output a constructor if it's documentated */
-  if (constructor.description || (constructor.params && constructor.params.length)) {
+  if (constructor.description || (constructor.params && constructor.params.length) || constructor.examples) {
     constructor.id = class_.id
     constructor.longname = class_.longname
     constructor.name = class_.codeName || class_.name


### PR DESCRIPTION
This fixes addresses the [linked issue](https://github.com/jsdoc2md/jsdoc-parse/issues/33):

```javascript
/**
 * @class LinkedList
 *
 * @example
 * const linkedList = new LinkedList();
 */
class LinkedList {
```

jsdoc-parse currently ignores the example in this scenario -- it only outputs constructor documentation if a description or `param` tags are present. With this change it checks for `example` tags as well.