### PR TITLE
Restore class names of default-exported modules

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -38,6 +38,7 @@ function transform (data) {
     doclet = renameThisProperty(doclet)
     doclet = removeMemberofFromModule(doclet)
     doclet = convertIsEnumFlagToKind(doclet)
+    doclet = renameModuleExports(doclet)
     return doclet
   })
 
@@ -400,4 +401,16 @@ function removeEnumChildren (json) {
       return true
     }
   })
+}
+
+/**
+ * Default exports lose their module name, showing up as module.exports, which
+ * is not very friendly. This restores the module name if we have it.
+ */
+function renameModuleExports(doclet) {
+  if (doclet.name === 'module.exports' && doclet.longname.startsWith('module:')) {
+    doclet.name = doclet.longname.replace('module:','')
+    console.log(doclet)
+  }
+  return doclet
 }


### PR DESCRIPTION
This is an attempt to resolve the downstream issue I just filed, https://github.com/jsdoc2md/jsdoc-to-markdown/issues/270 - see that issue for more details, but the short is, if we're parsing the following file:
```
/** module ExampleClass */

export default class ExampleClass {
  constructor() {}
}
```

Then we'll currently generate entries for the class and the constructor under `module.exports` because of how ES6 rewrites things internally. This uses the module name for the exported class and constructor instead, which is more in line with what end-users expect. There's an existing workaround with `@alias` for `jsdoc-to-markdown`, but it seems to me like just that - a suboptimal workaround.

That said, I'm not sure that this is the correct level to implement this remapping at - I don't know if this library is used widely outside of `jsdoc-to-markdown`, and if this would qualify as a breaking change. I looked into fixing it up in `jsdoc-to-markdown`, but since the results of `jsdoc-parse` are basically piped directly into `dmd`, it looked like it would require either elaborate template conditions, or a remapping similar to this, added to a pipeline that currently doesn't do any transformation of the result from `jsdoc-parse`.

But if this is a reasonable approach that's just not in the right place, it's a pretty simple transform, so it wouldn't be difficult to add into the pipeline in `jsdoc-to-markdown`.

Also the conditions I used for rewriting seem pretty conservative to me, but I'm not super familiar with the problem space here, so I don't know if there's a possibility of affecting other use cases.