### PR TITLE
remove lodash.pick due to CVE-2020-8203

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -2,8 +2,16 @@ const testValue = require('test-value')
 const where = testValue.where
 const arrayify = require('array-back')
 const extract = require('reduce-extract')
-const pick = require('lodash.pick')
 const omit = require('lodash.omit')
+
+function pick(object, keys) {
+  return keys.reduce((obj, key) => {
+     if (object && object.hasOwnProperty(key)) {
+        obj[key] = object[key];
+     }
+     return obj;
+   }, {});
+}
 
 /**
  * @module transform

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "array-back": "^6.2.2",
         "lodash.omit": "^4.5.0",
-        "lodash.pick": "^4.4.0",
         "reduce-extract": "^1.0.0",
         "sort-array": "^4.1.5",
         "test-value": "^3.0.0"
@@ -459,11 +458,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
       "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg=="
-    },
-    "node_modules/lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q=="
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -1101,11 +1095,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
       "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg=="
-    },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q=="
     },
     "minimatch": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "array-back": "^6.2.2",
     "lodash.omit": "^4.5.0",
-    "lodash.pick": "^4.4.0",
     "reduce-extract": "^1.0.0",
     "sort-array": "^4.1.5",
     "test-value": "^3.0.0"


### PR DESCRIPTION
Replaces lodash pick by with [this replacement](https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore?tab=readme-ov-file#_pick) due to being vulnerable to [CVE-2020-8203](https://github.com/advisories/GHSA-p6mc-m468-83gw).